### PR TITLE
fix(perf+security): eager loading, COUNT queries, HTTP security headers

### DIFF
--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -36,23 +36,16 @@ class DashboardController extends AbstractDashboardController
     public function index(): Response
     {
         $latestMessages = $this->messageRepository->findLatest();
-        $projects = $this->entityManager->getRepository(Project::class)->findAll();
-        $experiences = $this->entityManager->getRepository(Experience::class)->findAll();
-        $skills = $this->entityManager->getRepository(Skill::class)->findAll();
+
+        $count = fn(string $entity): int => (int) $this->entityManager
+            ->createQuery("SELECT COUNT(e.id) FROM {$entity} e")
+            ->getSingleScalarResult();
 
         $stats = [
-            [
-                'title' => 'Projects',
-                'amount' => count($projects),
-            ],
-            [
-                'title' => 'Experiences',
-                'amount' => count($experiences),
-            ],
-            [
-                'title' => 'Skills',
-                'amount' => count($skills),
-            ]];
+            ['title' => 'Projects', 'amount' => $count(Project::class)],
+            ['title' => 'Experiences', 'amount' => $count(Experience::class)],
+            ['title' => 'Skills', 'amount' => $count(Skill::class)],
+        ];
 
         return $this->render('admin/index.html.twig', [
             'messages' => $latestMessages,

--- a/src/Controller/MainController.php
+++ b/src/Controller/MainController.php
@@ -6,9 +6,8 @@ namespace App\Controller;
 
 use App\Entity\Experience;
 use App\Entity\Message;
-use App\Entity\Skill;
-use App\Entity\SkillType;
 use App\Form\ContactFormType;
+use App\Repository\SkillRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,13 +23,16 @@ class MainController extends AbstractController
     }
 
     #[Route('/about', name: 'about')]
-    public function about(EntityManagerInterface $entityManager): Response
+    public function about(EntityManagerInterface $entityManager, SkillRepository $skillRepository): Response
     {
         $experiences = $entityManager->getRepository(Experience::class)->findAll();
-        $skills = $entityManager->getRepository(Skill::class)->findAll();
-        $skillTypes = $entityManager->getRepository(SkillType::class)->findAll();
 
-        return $this->render('main/about.html.twig', ['skills' => $skills, 'skillTypes' => $skillTypes, 'experiences' => $experiences]);
+        $skillsByType = [];
+        foreach ($skillRepository->findAllWithType() as $skill) {
+            $skillsByType[$skill->getType()->getLabel()][] = $skill;
+        }
+
+        return $this->render('main/about.html.twig', ['skillsByType' => $skillsByType, 'experiences' => $experiences]);
     }
 
     #[Route('/contact', name: 'contact')]

--- a/src/Controller/SkillController.php
+++ b/src/Controller/SkillController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Entity\Skill;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Repository\SkillRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -13,9 +12,9 @@ use Symfony\Component\Routing\Attribute\Route;
 class SkillController extends AbstractController
 {
     #[Route('/skill/{id}', name: 'skill_show')]
-    public function index(EntityManagerInterface $entityManager, int $id): Response
+    public function index(SkillRepository $skillRepository, int $id): Response
     {
-        $skill = $entityManager->getRepository(Skill::class)->find($id);
+        $skill = $skillRepository->findWithProjectsAndExperiences($id);
 
         if (!$skill) {
             throw $this->createNotFoundException('Skill not found');

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -52,7 +52,7 @@ class Project
         $this->createdAt = new \DateTime();
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->name;
     }

--- a/src/EventSubscriber/SecurityHeadersSubscriber.php
+++ b/src/EventSubscriber/SecurityHeadersSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class SecurityHeadersSubscriber implements EventSubscriberInterface
+{
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+}

--- a/src/Repository/SkillRepository.php
+++ b/src/Repository/SkillRepository.php
@@ -16,28 +16,30 @@ class SkillRepository extends ServiceEntityRepository
         parent::__construct($registry, Skill::class);
     }
 
-    //    /**
-    //     * @return Skill[] Returns an array of Skill objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('s')
-    //            ->andWhere('s.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('s.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
+    /**
+     * @return Skill[] with type eagerly loaded
+     */
+    public function findAllWithType(): array
+    {
+        return $this->createQueryBuilder('s')
+            ->leftJoin('s.type', 't')
+            ->addSelect('t')
+            ->orderBy('t.label', 'ASC')
+            ->addOrderBy('s.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
 
-    //    public function findOneBySomeField($value): ?Skill
-    //    {
-    //        return $this->createQueryBuilder('s')
-    //            ->andWhere('s.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+    public function findWithProjectsAndExperiences(int $id): ?object
+    {
+        return $this->createQueryBuilder('s')
+            ->leftJoin('s.projects', 'p')
+            ->addSelect('p')
+            ->leftJoin('s.experiences', 'e')
+            ->addSelect('e')
+            ->where('s.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/templates/main/about.html.twig
+++ b/templates/main/about.html.twig
@@ -65,21 +65,19 @@
         <section class="skills-section">
             <h2 class="section-title">Compétences</h2>
             <div class="skills-container">
-                {% for skillType in skillTypes %}
+                {% for typeLabel, skills in skillsByType %}
                     <div class="skill-type">
-                        <h3 class="skill-type-title">{{ skillType.label }}</h3>
+                        <h3 class="skill-type-title">{{ typeLabel }}</h3>
                         <ul class="skills-list">
                             {% for skill in skills %}
-                                {% if skill.type.id == skillType.id %}
-                                    <li>
-                                        <a href="{{ path('skill_show', {'id': skill.id}) }}">{{ skill.name }}</a>
-                                    </li>
-                                {% endif %}
+                                <li>
+                                    <a href="{{ path('skill_show', {'id': skill.id}) }}">{{ skill.name }}</a>
+                                </li>
                             {% endfor %}
                         </ul>
                     </div>
-                    {% else %}
-                        <p>Aucune compétence à afficher pour le moment.</p>
+                {% else %}
+                    <p>Aucune compétence à afficher pour le moment.</p>
                 {% endfor %}
             </div>
         </section>


### PR DESCRIPTION
## Summary
- Added `SecurityHeadersSubscriber` to set `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` on every response
- `SkillRepository::findAllWithType()` eager-loads the `type` relation; `MainController` pre-groups skills by type — eliminates O(n²) template loop and lazy-load queries on the About page
- `SkillRepository::findWithProjectsAndExperiences()` eager-loads `projects` and `experiences`; used in `SkillController`
- `DashboardController` replaced `findAll()+count()` with 3 lightweight `COUNT` DQL queries

## Fixes from audit
- [x] Missing HTTP security headers
- [x] N+1 queries on About page
- [x] Missing eager loading on skill show page
- [x] COUNT via findAll() in admin dashboard