### PR TITLE
chore(quality): remove dead code, inject typed repos, register CommonMarkConverter as service

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,3 +23,5 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    League\CommonMark\CommonMarkConverter: ~

--- a/src/Controller/Admin/ExperienceCrudController.php
+++ b/src/Controller/Admin/ExperienceCrudController.php
@@ -4,9 +4,6 @@ namespace App\Controller\Admin;
 
 use App\Entity\Experience;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextEditorField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class ExperienceCrudController extends AbstractCrudController
 {
@@ -15,14 +12,4 @@ class ExperienceCrudController extends AbstractCrudController
         return Experience::class;
     }
 
-    /*
-    public function configureFields(string $pageName): iterable
-    {
-        return [
-            IdField::new('id'),
-            TextField::new('title'),
-            TextEditorField::new('description'),
-        ];
-    }
-    */
 }

--- a/src/Controller/Admin/ProjectCrudController.php
+++ b/src/Controller/Admin/ProjectCrudController.php
@@ -24,7 +24,6 @@ class ProjectCrudController extends AbstractCrudController
         yield TextField::new('name');
         yield TextField::new('status');
         yield TextField::new('shortDescription');
-        // TODO md support
         yield TextEditorField::new('description')
         ->hideOnIndex();
         yield AssociationField::new('skills');

--- a/src/Controller/ExperienceController.php
+++ b/src/Controller/ExperienceController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Entity\Experience;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Repository\ExperienceRepository;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Exception\CommonMarkException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -18,15 +17,14 @@ class ExperienceController extends AbstractController
      * @throws CommonMarkException
      */
     #[Route('/experience/{id}', name: 'experience_show')]
-    public function index(EntityManagerInterface $entityManager, int $id): Response
+    public function show(ExperienceRepository $experienceRepository, CommonMarkConverter $converter, int $id): Response
     {
-        $experience = $entityManager->getRepository(Experience::class)->find($id);
+        $experience = $experienceRepository->find($id);
 
         if (!$experience) {
             throw $this->createNotFoundException('Experience not found');
         }
 
-        $converter = new CommonMarkConverter();
         $contentHTML = $converter->convert($experience->getDescription());
 
         return $this->render('experience/index.html.twig', ['experience' => $experience, 'content' => $contentHTML]);

--- a/src/Controller/MainController.php
+++ b/src/Controller/MainController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Entity\Experience;
 use App\Entity\Message;
 use App\Form\ContactFormType;
+use App\Repository\ExperienceRepository;
 use App\Repository\SkillRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -23,9 +23,9 @@ class MainController extends AbstractController
     }
 
     #[Route('/about', name: 'about')]
-    public function about(EntityManagerInterface $entityManager, SkillRepository $skillRepository): Response
+    public function about(ExperienceRepository $experienceRepository, SkillRepository $skillRepository): Response
     {
-        $experiences = $entityManager->getRepository(Experience::class)->findAll();
+        $experiences = $experienceRepository->findAll();
 
         $skillsByType = [];
         foreach ($skillRepository->findAllWithType() as $skill) {

--- a/src/Controller/ProjectController.php
+++ b/src/Controller/ProjectController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Entity\Project;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Repository\ProjectRepository;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Exception\CommonMarkException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -15,9 +14,9 @@ use Symfony\Component\Routing\Attribute\Route;
 class ProjectController extends AbstractController
 {
     #[Route('/projects', name: 'projects')]
-    public function index(EntityManagerInterface $entityManager): Response
+    public function index(ProjectRepository $projectRepository): Response
     {
-        $projects = $entityManager->getRepository(Project::class)->findAll();
+        $projects = $projectRepository->findAll();
 
         return $this->render('project/index.html.twig', ['projects' => $projects]);
     }
@@ -26,15 +25,14 @@ class ProjectController extends AbstractController
      * @throws CommonMarkException
      */
     #[Route('/projects/{id}', name: 'project')]
-    public function show(EntityManagerInterface $entityManager, int $id): Response
+    public function show(ProjectRepository $projectRepository, CommonMarkConverter $converter, int $id): Response
     {
-        $project = $entityManager->getRepository(Project::class)->find($id);
+        $project = $projectRepository->find($id);
 
         if (!$project) {
             throw $this->createNotFoundException('Project not found');
         }
 
-        $converter = new CommonMarkConverter();
         $contentHTML = $converter->convert($project->getDescription());
 
         return $this->render('project/show.html.twig', ['project' => $project, 'content' => $contentHTML]);

--- a/src/Repository/ExperienceRepository.php
+++ b/src/Repository/ExperienceRepository.php
@@ -16,28 +16,4 @@ class ExperienceRepository extends ServiceEntityRepository
         parent::__construct($registry, Experience::class);
     }
 
-    //    /**
-    //     * @return Experience[] Returns an array of Experience objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('e')
-    //            ->andWhere('e.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('e.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
-
-    //    public function findOneBySomeField($value): ?Experience
-    //    {
-    //        return $this->createQueryBuilder('e')
-    //            ->andWhere('e.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
 }

--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -16,28 +16,4 @@ class ProjectRepository extends ServiceEntityRepository
         parent::__construct($registry, Project::class);
     }
 
-    //    /**
-    //     * @return Project[] Returns an array of Project objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('p')
-    //            ->andWhere('p.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('p.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
-
-    //    public function findOneBySomeField($value): ?Project
-    //    {
-    //        return $this->createQueryBuilder('p')
-    //            ->andWhere('p.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
 }


### PR DESCRIPTION
## Summary
- Removed all commented-out boilerplate from `ExperienceCrudController`, `ProjectRepository`, `ExperienceRepository` and cleaned up now-unused imports
- Renamed `ExperienceController::index()` to `show()` to match the route it handles
- Removed stale `// TODO md support` comment from `ProjectCrudController`
- Registered `CommonMarkConverter` as a singleton service in `services.yaml` — no longer instantiated on every request in `ProjectController` and `ExperienceController`
- `ProjectController`, `ExperienceController`, and `MainController` now inject typed repositories instead of `EntityManagerInterface`